### PR TITLE
Feat: 시멘틱 아티클 본문 판별 알고리즘 작성(공통 요소)

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,7 +1,12 @@
 {
   "compilerOptions": {
     "target": "ES6",
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "baseUrl": "./src",
+    "paths": {
+      "*": ["*"],
+      "utils/*": ["utils/*"]
+    }
   },
   "exclude": ["node_modules"]
 }

--- a/src/app.controller.js
+++ b/src/app.controller.js
@@ -17,16 +17,16 @@ export class AppController {
 
     try {
       const formattedURL = this.appService.formatHttpURL(url);
+
       const { headElement, bodyElement } =
         await this.appService.getHtmlElement(formattedURL);
-
       const readingTime = this.appService.getReadingTime(bodyElement, wpm);
       const siteOpenGraph = this.appService.getSiteOpenGraph(
         headElement,
         formattedURL,
       );
 
-      return response.status(HttpStatus.OK.statusCode).send({
+      response.status(HttpStatus.OK.statusCode).send({
         status: HttpStatus.OK.statusCode,
         data: {
           readingTime,
@@ -36,10 +36,12 @@ export class AppController {
     } catch (error) {
       if (error instanceof HttpError) {
         const { statusCode, message } = error.getError();
+
         response.status(statusCode).send({ statusCode, message });
       }
 
       const { statusCode, message } = HttpStatus.INTERNAR_SERVER_ERROR;
+
       response.status(statusCode).send({ statusCode, message });
     }
 

--- a/src/app.controller.js
+++ b/src/app.controller.js
@@ -1,10 +1,48 @@
-import { Controller, Dependencies, Get } from "@nestjs/common";
+import { Controller, Dependencies, Get, Bind, Req, Res } from "@nestjs/common";
+
 import { AppService } from "./app.service";
+import { HttpError, HttpStatus } from "./utils/http";
 
 @Controller()
 @Dependencies(AppService)
 export class AppController {
   constructor(appService) {
     this.appService = appService;
+  }
+
+  @Get("/readingTime")
+  @Bind(Req(), Res())
+  async getReadingTime(request, response) {
+    const { url, wpm = 202 } = request.query;
+
+    try {
+      const formattedURL = this.appService.formatHttpURL(url);
+      const { headElement, bodyElement } =
+        await this.appService.getHtmlElement(formattedURL);
+
+      const readingTime = this.appService.getReadingTime(bodyElement, wpm);
+      const siteOpenGraph = this.appService.getSiteOpenGraph(
+        headElement,
+        formattedURL,
+      );
+
+      return response.status(HttpStatus.OK.statusCode).send({
+        status: HttpStatus.OK.statusCode,
+        data: {
+          readingTime,
+          ...siteOpenGraph,
+        },
+      });
+    } catch (error) {
+      if (error instanceof HttpError) {
+        const { statusCode, message } = error.getError();
+        response.status(statusCode).send({ statusCode, message });
+      }
+
+      const { statusCode, message } = HttpStatus.INTERNAR_SERVER_ERROR;
+      response.status(statusCode).send({ statusCode, message });
+    }
+
+    return null;
   }
 }

--- a/src/app.controller.spec.js
+++ b/src/app.controller.spec.js
@@ -1,4 +1,6 @@
 import { Test } from "@nestjs/testing";
+import jsdom from "jsdom";
+
 import { AppController } from "./app.controller";
 import { AppService } from "./app.service";
 
@@ -39,7 +41,7 @@ describe("AppController", () => {
       const articleBody =
         "연합뉴스 육군 제12사단에서 규정에 어긋난 군기 훈련(얼차려)을 받다 숨진 박모 훈련병의 수료식이 19일 열린 가운데 ‘상관이 시킨다고 무조건 듣지 말라’고 당부하는 입대 장병 부모가 늘고 있다. 아들을 고(故) 박 훈련병과 함께 입대했다고 밝힌 아버지 A씨는 최근 JTBC 유튜브 ‘뉴스들어가혁’과 인터뷰에서 “아들을 (수료식에서) 만나면 ‘그냥 시키는 것만 하고 나서지 말라’ ‘절대 건강하라’는 말을 해주고 싶다”면서 아들을 비롯해 군 복무하는 모든 장병에게 ‘너무 힘들면 영창에 갈 것을 각오하고라도 상관의 명령을 거부하라’는 취지로 발언했다. A씨는 “건강은 너희가 지켜야지 아무도 챙겨주지 않는다(는 말을 해주고 싶다)”면서 “입대할 때는 (군에 보낸 아들이) 대한민국의 군인이라고 그렇게 부모들에게 자랑하더니 무슨 사고만 터지면 ‘당신 아들’이라며 외면을 하니 누가 자식을 믿고 군에 보내겠느냐”고 목소리를 높였다. 고 박 훈련병 관련 소식을 전한 국민일보 뉴스에도 “5만 군 가족이 지켜보고 있다. 하루하루 애국심이 바닥으로 떨어진다” “멀쩡한 청년이 국방의 의무를 이행하러 갔다가 지휘관에 의해 고문당해 죽은 것이 이 사건의 본질이다” “군에 무늬만 군인인 국방 조무사로 가득하다. 뒤집어엎어야 한다” 등 군 당국을 비판하는 댓글이 잔뜩 달렸다. 한편 이날 고 박 훈련병의 어머니 B씨는 군인권센터를 통해 아들이 군기 훈련을 받은 상황과 쓰러진 뒤 군의 조치에 대해 문제를 제기했다. 그는 “군이 아들에게 씌운 프레임은 ‘떠들다 (규칙을 어겨) 얼차려를 받은 것’이었는데 아들이 동기들과 실제로 나눈 말은 ‘조교를 하면 아침에 일찍 일어나야겠다’와 같은 것들이었다”면서 “내 아들과 잔악한 선착순 달리기를 시키고 언제 끝날지 모르는 구보를 뛰게 하다 아들을 쓰러뜨린 중대장 중 누가 규칙을 더 많이 어겼느냐”고 지적했다. 강원경찰청 훈련병 사망 사건 수사 전담팀은 사건 발생 26일 만인 지난 18일 해당 중대장과 부중대장에게 직권남용가혹행위와 업무상과실치사 혐의를 적용해 검찰에 구속 영장을 신청했다. 김진욱 기자 reality@kmib.co.kr 경제부 김진욱 기자 reality@kmib.co.kr 응원하기 금융권 소식을 전합니다. GoodNews paper ⓒ 국민일보(www.kmib.co.kr), 무단전재, 수집, 재배포 및 AI학습 이용 금지 ";
 
-      expect(appService.getReadingTime(articleBody, userWPM)).toBe(90000);
+      expect(appService.calculateReadingTime(articleBody, userWPM)).toBe(90000);
     });
 
     it("should return 60,000ms", () => {
@@ -48,7 +50,69 @@ describe("AppController", () => {
       const articleBody =
         "이국종 대전국군병원장. 뉴시스 이국종 대전국군병원장이 “이미 한국 필수의료는 초토화된 상태”라면서 의대 정원 확대로 필수의료 기피 문제를 해결하기 어렵다고 지적했다. 중증외상 분야 국내 최고 권위자인 이 병원장이 의대 증원에 대한 입장을 공식 석상에서 밝힌 건 처음이다. 이 병원장은 지난 19일 대전 유성구 국립중앙과학관에서 지역 교사들을 대상으로 열린 ‘명강연 콘서트’에서 “현재 의료계는 벌집이 터졌고 전문의는 더 이상 배출되지 않아 없어질 것”이라고 말했다. 그는 의대 정원 확대가 필수의료 의사 확보에 실질적인 효과를 거두기 어렵다고 지적했다. 이 병원장은 “30년 전과 비교해 소아과 전문의는 3배 늘었고 신생아는 4분의 1 수준으로 줄었지만 정작 부모들은 병원이 없어 ‘오픈런’을 한다”며 “이런 상황에서 의대생을 200만명 늘린다고 해서 소아과를 하겠느냐”고 말했다. 이 병원장은 “‘필수의료과가 망한다’는 말은 내가 의대생이던 30~40년 전부터 나왔다”면서 “정부 정책의 실패”라고 비판했다. 그는 “지금 의사가 부족하다고 하는데 내가 전문의를 취득한 1999년에는 의사가 너무 많아 해외로 수출해야 한다고 했다. 얼마 전까지는 미용으로 의료 관광을 육성한다고 하더니 이젠 필수의료를 살려야 한다고 한다”며 “하지만 이미 한국 필수의료는 초토화된 상태”라고 말했다. 이 병원장은 필수의료 시스템부터 다져야 한다고 강조했다. 그는 “해외에서 한국 같은 ‘응급실 뺑뺑이’는 상상도 할 수 없다”며 “미국은 환자가 병원에 도착하기도 전에 의사와 간호사가 대기하는 이런 시스템을 20년 전부터 갖췄다”고 말했다. 일본이 연간 1800번 닥터헬기를 띄운다면 한국은 미군 헬기까지 동원해도 출동 횟수가 300번이 채 되지 않는다는 지적이다. 그는 “앞으로 전문의가 배출되지 않아 사라질 것”이라며 “의료계가 몇 달째 머리를 맞대고 있어도 답이 나오지 않고 있지만 최선을 다할 것”이라고 덧붙였다. 정신영 기자 spirit@kmib.co.kr GoodNews paper ⓒ 국민일보(www.kmib.co.kr), 무단전재, 수집, 재배포 및 AI학습 이용 금지 ";
 
-      expect(appService.getReadingTime(articleBody, userWPM)).toBe(60000);
+      expect(appService.calculateReadingTime(articleBody, userWPM)).toBe(60000);
+    });
+  });
+
+  describe("getReadingTime test02", () => {
+    it("should return head, body element", async () => {
+      const url = "https://ko.react.dev/learn";
+      const appService = app.get(AppService);
+      const elements = await appService.getHtmlElement(url);
+
+      const { headElement, bodyElement } = elements;
+
+      expect(headElement.tagName).toBe("HEAD");
+      expect(bodyElement.tagName).toBe("BODY");
+    });
+
+    it("should remove excludedTags", () => {
+      const { JSDOM } = jsdom;
+      const dom = new JSDOM(
+        `<!DOCTYPE html>
+        <main>
+          <article>
+            <img src="/" alt="test" />
+            <div id="include">include</div>
+            <button>버튼</button>
+          </article>
+        </main>
+        `,
+      );
+
+      const mainElement = dom.window.document.querySelector("main");
+
+      const appService = app.get(AppService);
+      appService.removeExcludedTags(mainElement);
+
+      const articleElement = mainElement.querySelector("article");
+      expect(articleElement.textContent).not.toBeNull();
+
+      const divElement = mainElement.querySelector("#include");
+      expect(divElement.textContent).toBe("include");
+
+      const buttonElement = mainElement.querySelector("button");
+      expect(buttonElement).toBeNull();
+
+      const imgElement = mainElement.querySelector("img");
+      expect(imgElement).toBeNull();
+    });
+
+    it("should add space between tags", () => {
+      const { JSDOM } = jsdom;
+      const dom = new JSDOM(
+        `<!DOCTYPE html><main><span id="first">하나</span><span>둘</span></main>`,
+      );
+
+      const mainElement = dom.window.document.querySelector("main");
+      const firstSpanElement = dom.window.document.querySelector("#first");
+
+      const appService = app.get(AppService);
+      appService.addSpaceBetweenTags(firstSpanElement);
+
+      expect(mainElement.innerHTML).toBe(
+        `<span id="first">하나 </span><span>둘</span>`,
+      );
     });
   });
 });

--- a/src/app.controller.spec.js
+++ b/src/app.controller.spec.js
@@ -15,12 +15,20 @@ describe("AppController", () => {
   describe("Convert code to text", () => {
     it("should return a string of words with only words and spaces", () => {
       const appService = app.get(AppService);
-      expect(appService.convertCodeToText("let {top, bottom, left, right} = Directions;")).toBe("let top bottom left right Directions");
+      expect(
+        appService.convertCodeToText(
+          "let {top, bottom, left, right} = Directions;",
+        ),
+      ).toBe("let top bottom left right Directions");
     });
 
     it("should return a string of words with only words and spaces", () => {
       const appService = app.get(AppService);
-      expect(appService.convertCodeToText(`<div className="mb-4 overflow-scroll font-sans"></div>`)).toBe("div class Name mb 4 overflow scroll font sans div");
+      expect(
+        appService.convertCodeToText(
+          `<div className="mb-4 overflow-scroll font-sans"></div>`,
+        ),
+      ).toBe("div class Name mb 4 overflow scroll font sans div");
     });
   });
 
@@ -44,4 +52,3 @@ describe("AppController", () => {
     });
   });
 });
-

--- a/src/app.controller.spec.js
+++ b/src/app.controller.spec.js
@@ -59,7 +59,6 @@ describe("AppController", () => {
       const url = "https://ko.react.dev/learn";
       const appService = app.get(AppService);
       const elements = await appService.getHtmlElement(url);
-
       const { headElement, bodyElement } = elements;
 
       expect(headElement.tagName).toBe("HEAD");

--- a/src/app.service.js
+++ b/src/app.service.js
@@ -47,8 +47,8 @@ export class AppService {
 
   removeExcludedTags(element) {
     const stack = [];
-
     const descendingChildren = Array.from(element.children).reverse();
+
     stack.push(...descendingChildren);
 
     while (stack.length > 0) {
@@ -57,9 +57,11 @@ export class AppService {
 
       if (EXCLUDED_TAGS_REGEX.test(tagName)) {
         const { parentElement } = currentElement;
+
         parentElement.removeChild(currentElement);
       } else {
         const reversedChildren = Array.from(currentElement.children).reverse();
+
         stack.push(...reversedChildren);
       }
     }
@@ -67,8 +69,8 @@ export class AppService {
 
   convertElementsWithRules(element) {
     const stack = [];
-
     const descendingChildren = Array.from(element.children).reverse();
+
     stack.push(...descendingChildren);
 
     while (stack.length > 0) {
@@ -78,6 +80,7 @@ export class AppService {
       this.convertCodeTagToText(currentElement);
 
       const reversedChildren = Array.from(currentElement.children).reverse();
+
       stack.push(...reversedChildren);
     }
   }
@@ -101,6 +104,7 @@ export class AppService {
 
     if (tagName === "pre") {
       const text = this.convertCodeToText(element.textContent);
+
       element.innerHTML = text;
     }
   }
@@ -108,8 +112,8 @@ export class AppService {
   reduceMainContentElements(body) {
     const mainContentElements = [];
     const stack = [];
-
     const reversedBodyChildren = Array.from(body.children).reverse();
+
     stack.push(...reversedBodyChildren);
 
     while (stack.length > 0) {
@@ -120,6 +124,7 @@ export class AppService {
         mainContentElements.push(currentElement);
       } else if (!EXCLUDED_TAGS_REGEX.test(tagName)) {
         const reversedChildren = Array.from(currentElement.children).reverse();
+
         stack.push(...reversedChildren);
       }
     }
@@ -169,10 +174,8 @@ export class AppService {
     const title =
       this.getOpenGraph("title", headElement) ||
       headElement.querySelector("title")?.textContent;
-
     const adress =
       headElement.querySelector("link[rel*='canonical']")?.href || url;
-
     const siteMatchName = adress.match(STIE_NAME_REGEX);
     const siteName =
       this.getOpenGraph("site_name", headElement) ||

--- a/src/app.service.js
+++ b/src/app.service.js
@@ -1,7 +1,139 @@
 import { Injectable } from "@nestjs/common";
+import jsdom from "jsdom";
+
+import { HttpError, HttpStatus } from "./utils/http";
+
+const EXCLUDED_TAGS_REGEX =
+  /^(button|img|nav|aside|footer|audio|canvas|embed|figure|iframe|map|area|noscript|object|option|optgroup|picture|progress|script|select|source|style|svg)$/i;
+const MAIN_CONTENT_TAGS_REGEX = /^(main|article|section|header)$/i;
+const ENTER_REGEX = /[\n]/g;
+const TAB_REGEX = /[\t]/g;
+const WHITESPACE_REGEX = /\s+/g;
+const STIE_NAME_REGEX = /https?:\/\/(?:www\.)?([^\.\/]+)/;
 
 @Injectable()
 export class AppService {
+  async getHtmlElement(url) {
+    try {
+      const { JSDOM } = jsdom;
+      const dom = await JSDOM.fromURL(url);
+      const { document } = dom.window;
+
+      return {
+        headElement: document.documentElement.querySelector("head"),
+        bodyElement: document.documentElement.querySelector("body"),
+      };
+    } catch (error) {
+      throw new HttpError(HttpStatus.BAD_URL);
+    }
+  }
+
+  getReadingTime(bodyElement, wpm) {
+    const mainContentElements = this.reduceMainContentElements(bodyElement);
+
+    const contents = mainContentElements.reduce((acc, element) => {
+      this.removeExcludedTags(element);
+      this.convertElementsWithRules(element);
+
+      return acc.concat(this.parseElementIntoTextContent(element));
+    }, []);
+
+    if (contents.length === 0) {
+      throw new HttpError(HttpStatus.PARSE_ERROR);
+    }
+
+    return this.calculateReadingTime(contents.join(" "), wpm);
+  }
+
+  removeExcludedTags(element) {
+    const stack = [];
+
+    const descendingChildren = Array.from(element.children).reverse();
+    stack.push(...descendingChildren);
+
+    while (stack.length > 0) {
+      const currentElement = stack.pop();
+      const tagName = currentElement.tagName.toLowerCase();
+
+      if (EXCLUDED_TAGS_REGEX.test(tagName)) {
+        const { parentElement } = currentElement;
+        parentElement.removeChild(currentElement);
+      } else {
+        const reversedChildren = Array.from(currentElement.children).reverse();
+        stack.push(...reversedChildren);
+      }
+    }
+  }
+
+  convertElementsWithRules(element) {
+    const stack = [];
+
+    const descendingChildren = Array.from(element.children).reverse();
+    stack.push(...descendingChildren);
+
+    while (stack.length > 0) {
+      const currentElement = stack.pop();
+
+      this.addSpaceBetweenTags(currentElement);
+      this.convertCodeTagToText(currentElement);
+
+      const reversedChildren = Array.from(currentElement.children).reverse();
+      stack.push(...reversedChildren);
+    }
+  }
+
+  addSpaceBetweenTags(element) {
+    if (!element.nextSibling) {
+      return;
+    }
+
+    const { nextSibling } = element;
+
+    if (nextSibling.nodeType === 3 && nextSibling.textContent === "\n") {
+      element.innerHTML += " ";
+    } else if (element.nodeType === 1 && nextSibling.nodeType === 1) {
+      element.innerHTML += " ";
+    }
+  }
+
+  convertCodeTagToText(element) {
+    const tagName = element.tagName.toLowerCase();
+
+    if (tagName === "pre") {
+      const text = this.convertCodeToText(element.textContent);
+      element.innerHTML = text;
+    }
+  }
+
+  reduceMainContentElements(body) {
+    const mainContentElements = [];
+    const stack = [];
+
+    const reversedBodyChildren = Array.from(body.children).reverse();
+    stack.push(...reversedBodyChildren);
+
+    while (stack.length > 0) {
+      const currentElement = stack.pop();
+      const tagName = currentElement.tagName.toLowerCase();
+
+      if (MAIN_CONTENT_TAGS_REGEX.test(tagName)) {
+        mainContentElements.push(currentElement);
+      } else if (!EXCLUDED_TAGS_REGEX.test(tagName)) {
+        const reversedChildren = Array.from(currentElement.children).reverse();
+        stack.push(...reversedChildren);
+      }
+    }
+
+    return mainContentElements;
+  }
+
+  parseElementIntoTextContent(element) {
+    return element.textContent
+      .replace(ENTER_REGEX, " ")
+      .replace(TAB_REGEX, " ")
+      .replace(WHITESPACE_REGEX, " ");
+  }
+
   convertCodeToText(code) {
     const CodeText = code
       .replace(/([a-z])([A-Z])/g, "$1 $2")
@@ -12,9 +144,9 @@ export class AppService {
     return CodeText;
   }
 
-  getReadingTime(articleBody, userWPM) {
+  calculateReadingTime(articleBody, wpm) {
     const numOfWords = articleBody.split(" ").length;
-    const rawReadingTime = (numOfWords / userWPM) * 60 * 1000;
+    const rawReadingTime = (numOfWords / wpm) * 60 * 1000;
     let readingMinutes = Math.floor(rawReadingTime / 1000 / 60);
     let readingSeconds =
       Math.round((rawReadingTime / 1000 - readingMinutes * 60) * 0.1) * 10;
@@ -31,5 +163,42 @@ export class AppService {
     const readingTimePerMs = readingMinutes * 60 * 1000 + readingSeconds * 1000;
 
     return readingTimePerMs;
+  }
+
+  getSiteOpenGraph(headElement, url) {
+    const title =
+      this.getOpenGraph("title", headElement) ||
+      headElement.querySelector("title")?.textContent;
+
+    const adress =
+      headElement.querySelector("link[rel*='canonical']")?.href || url;
+
+    const siteMatchName = adress.match(STIE_NAME_REGEX);
+    const siteName =
+      this.getOpenGraph("site_name", headElement) ||
+      (siteMatchName && siteMatchName[1]);
+
+    return {
+      title,
+      siteName,
+      url: adress,
+      faviconUrl: headElement.querySelector("link[rel*='icon']").href,
+    };
+  }
+
+  getOpenGraph(property, headElement) {
+    const content = headElement.querySelector(
+      `meta[property='og:${property}'], meta[name='${property}']`,
+    )?.content;
+
+    return content;
+  }
+
+  formatHttpURL(url) {
+    if (!url.startsWith("https://") && !url.startsWith("http://")) {
+      return `https://${url}`;
+    }
+
+    return url;
   }
 }

--- a/src/utils/http.js
+++ b/src/utils/http.js
@@ -1,0 +1,36 @@
+export const HttpStatus = {
+  OK: {
+    statusCode: 200,
+    message: "OK",
+  },
+  INVALID_REQUEST: {
+    statusCode: 400,
+    message: "The bad request",
+  },
+  BAD_URL: {
+    statusCode: 400,
+    message: "Invalid URL",
+  },
+  PARSE_ERROR: {
+    statusCode: 512,
+    message: "Failed To Parse The Article",
+  },
+  INTERNAR_SERVER_ERROR: {
+    statusCode: 500,
+    message: "Internal Server Error",
+  },
+};
+
+export class HttpError extends Error {
+  constructor({ statusCode, message }) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+
+  getError() {
+    return {
+      message: this.message,
+      statusCode: this.statusCode,
+    };
+  }
+}


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈가 있다면 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
### Resolves: #7

- 시멘틱 태그로 구성된 사이트의 본문 판별을 위해 다음 알고리즘을 작성했습니다.
  - JSDOM을 이용해 사이트의 document 요소를 가져와 본문을 판별하는 알고리즘을 작성했습니다.
  - 본문 판별 알고리즘을 통해 반환받은 본문 요소들 중 불필요한 요소를 제거하는 알고리즘과 텍스트를 추출하는 알고리즘을 작성했습니다.
- HTTP 요청에 대한 응답 값 반환과 상황별 API 에러 처리를 위한 클래스와 상수를 작성했습니다.
- 본문의 카드에 보여 줄 정보를 위해 open graph 정보를 반환 함수를 작성했습니다.
- service의 함수를 테스트하기 위한 테스트 코드를 작성했습니다.

## 코드 변경 사항
함수명 중복으로 인해 기존 getReadingTime 함수명을 calculateReadingTime 함수명으로 변경했습니다.

## 기타 전달 사항

## PR Checklist
- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
