### PR TITLE
Feat: Velog 대응 본문 판별 로직 추가

### DIFF
--- a/src/app.controller.js
+++ b/src/app.controller.js
@@ -20,7 +20,11 @@ export class AppController {
 
       const { headElement, bodyElement } =
         await this.appService.getHtmlElement(formattedURL);
-      const readingTime = this.appService.getReadingTime(bodyElement, wpm);
+      const readingTime = this.appService.getReadingTime(
+        formattedURL,
+        bodyElement,
+        wpm,
+      );
       const siteOpenGraph = this.appService.getSiteOpenGraph(
         headElement,
         formattedURL,
@@ -31,6 +35,7 @@ export class AppController {
         data: {
           readingTime,
           ...siteOpenGraph,
+          createDate: new Date().toISOString(),
         },
       });
     } catch (error) {
@@ -44,5 +49,54 @@ export class AppController {
 
       return response.status(statusCode).send({ statusCode, message });
     }
+  }
+
+  @Get("/article")
+  @Bind(Req(), Res())
+  async getArticle(request, response) {
+    const { url } = request.query;
+
+    try {
+      const formattedURL = this.appService.formatHttpURL(url);
+
+      const { bodyElement } =
+        await this.appService.getHtmlElement(formattedURL);
+      const article = this.appService.getMainContent(bodyElement);
+
+      return response.status(HttpStatus.OK.statusCode).send({
+        statusCode: HttpStatus.OK.statusCode,
+        data: {
+          article,
+        },
+      });
+    } catch (error) {
+      if (error instanceof HttpError) {
+        const { statusCode, message } = error.getError();
+
+        return response.status(statusCode).send({ statusCode, message });
+      }
+
+      const { statusCode, message } = HttpStatus.INTERNAR_SERVER_ERROR;
+
+      return response.status(statusCode).send({ statusCode, message });
+    }
+  }
+
+  @Get("/velog")
+  @Bind(Req(), Res())
+  async getArticlebody(request, response) {
+    const { url } = request.query;
+
+    const formattedURL = this.appService.formatHttpURL(url);
+
+    const { bodyElement } = await this.appService.getHtmlElement(formattedURL);
+    const article = this.appService.getVelogMainContent(bodyElement);
+
+    return response.status(HttpStatus.OK.statusCode).send({
+      statusCode: HttpStatus.OK.statusCode,
+      data: {
+        article,
+      },
+    });
   }
 }

--- a/src/app.controller.spec.js
+++ b/src/app.controller.spec.js
@@ -117,7 +117,8 @@ describe("AppController", () => {
     it("outer articles should be the main content", () => {
       const appService = app.get(AppService);
       const html = `<!DOCTYPE html>
-        <html lang="en"><head>
+        <html lang="en">
+        <head>
           <meta charset="UTF-8">
           <meta name="viewport" content="width=device-width, initial-scale=1.0">
           <title>Document</title>
@@ -151,6 +152,76 @@ describe("AppController", () => {
 
       expect(mainContentElements.length).toBe(2);
       expect(content).toBe("title section1 section2 div1 div2 div3 div4");
+    });
+  });
+
+  describe("getVelogMainContents", () => {
+    it("velog have title & main content", () => {
+      const appService = app.get(AppService);
+      const html = `<!DOCTYPE html>
+        <html lang="en">
+        <head>
+          <meta charset="UTF-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <title>Document</title>
+        </head>
+        <body>
+          <div id="root">
+            <div class="__jazzbar false false"></div>
+            <div class="sc-dpilbb sc-bBHHxi kTIDXm">
+              <div class="sc-bBHxTw jEdNvQ"></div>
+              <div style="margin-top: -64px; opacity: 0;" class="sc-cTA qQK bxsBRa"></div>
+              <div class="sc-TBWPX dXONqK sc-jQrDum fiOuRZ">
+                <div class="head-wrapper">
+                  <h1>Velog(벨로그) 본문 추출법</h1>
+                  <span>2024년 6월 24일</span>
+                </div>
+              </div>
+              <div class="sc-TBWPX dXONqK sc-kmQMED cALPIq"></div>
+              <div class="sc-dFtzxp bfzjcP">
+                <p>
+                  <img src="https://velog...png">
+                </p>
+                <h2 id="클래스 네임 규칙">난수로 보이지만 규칙이 있습니다</h2>
+                <span>클래스 명에 "TBWPX"를 포함하는 첫번째 div와</span>
+                <span>그 자식들만 title 정보를 담고 있습니다</span>
+              </div>
+              <div class="sc-TBWX dXONqK sc-djWRfJ bksdVp">
+                <div>
+                  <p>이하 나머지 "TBWX"를 포함하는 태그들은, 기타 정보를 담습니다</p>
+                </div>
+              </div>
+              <div class="sc-TBWPX dXONqK sc-fIosK dpmQGl"></div>
+              <div class="sc-dFtzxp bfzjcP">
+                <div class="sc-bxTejn FTZwa">
+                  <div class="sc-eGRUor gdnhbG atom-one">
+                    <p>그리고, 클래스명에 "dFtzxp"를 포함하는 div와</p>
+                      <span>그 자식요소들이</span>
+                    <p>본문 요소들을 담고 있습니다</p>
+                  </div>
+                </div>
+              </div>
+              <div class="sc-TBWPX dXONqK sc-brSvTw cgYvDI"></div>
+              <div class="sc-cLpAjG cFmnmV"></div>
+              <div class="sc-gslxeA eUVKAp"></div>
+            </div>
+          </div>
+        <script></script>
+        <script></script>
+        <script></script>
+        </body>
+        </html>`;
+      const { JSDOM } = jsdom;
+      const dom = new JSDOM(html);
+      const bodyElement = dom.window.document.querySelector("body");
+      console.log(bodyElement.innerHTML);
+      const velogMaincontent = appService
+        .getVelogMainContent(bodyElement)
+        .replace(/\s+/g, " ");
+
+      expect(velogMaincontent).toBe(
+        ` Velog(벨로그) 본문 추출법 2024년 6월 24일 난수로 보이지만 규칙이 있습니다 클래스 명에 "TBWPX"를 포함하는 첫번째 div와 그 자식들만 title 정보를 담고 있습니다 그리고, 클래스명에 "dFtzxp"를 포함하는 div와 그 자식요소들이 본문 요소들을 담고 있습니다 `,
+      );
     });
   });
 });

--- a/src/app.service.js
+++ b/src/app.service.js
@@ -38,6 +38,7 @@ export class AppService {
 
       return this.calculateReadingTime(velogMainContent, wpm);
     }
+
     const mainContent = this.getMainContent(bodyElement);
 
     return this.calculateReadingTime(mainContent, wpm);

--- a/src/app.service.js
+++ b/src/app.service.js
@@ -32,8 +32,14 @@ export class AppService {
     }
   }
 
-  getReadingTime(bodyElement, wpm) {
-    const mainContent = this.getMainContent(bodyElement);
+  getReadingTime(url, bodyElement, wpm) {
+    let mainContent = null;
+
+    if (url.includes("velog")) {
+      mainContent = this.getVelogMainContent(bodyElement);
+    } else {
+      mainContent = this.getMainContent(bodyElement);
+    }
 
     return this.calculateReadingTime(mainContent, wpm);
   }
@@ -225,5 +231,35 @@ export class AppService {
 
   formatHttpURL(url) {
     return url.replace(/^(?!https?:\/\/)/, "https://");
+  }
+
+  getVelogMainContent(bodyElement) {
+    const allElements = Array.from(bodyElement.querySelectorAll("*"));
+
+    const titleElement = allElements.find((element) => {
+      return (
+        typeof element.className === "string" &&
+        element.className.toLowerCase().includes("tbwpx")
+      );
+    });
+
+    const mainElements = allElements.filter((element) => {
+      return (
+        typeof element.className === "string" &&
+        element.className.toLowerCase().includes("dftzxp")
+      );
+    });
+
+    const velogMainArticle = titleElement
+      ? [titleElement, ...mainElements]
+      : mainElements;
+
+    const velogMainContent = velogMainArticle.reduce((acc, element) => {
+      this.convertElementsWithRules(element);
+
+      return acc.concat(this.parseElementIntoTextContent(element));
+    }, []);
+
+    return velogMainContent.join(" ");
   }
 }

--- a/src/app.service.js
+++ b/src/app.service.js
@@ -33,13 +33,12 @@ export class AppService {
   }
 
   getReadingTime(url, bodyElement, wpm) {
-    let mainContent = null;
+    if (url.includes("velog.io")) {
+      const velogMainContent = this.getVelogMainContent(bodyElement);
 
-    if (url.includes("velog")) {
-      mainContent = this.getVelogMainContent(bodyElement);
-    } else {
-      mainContent = this.getMainContent(bodyElement);
+      return this.calculateReadingTime(velogMainContent, wpm);
     }
+    const mainContent = this.getMainContent(bodyElement);
 
     return this.calculateReadingTime(mainContent, wpm);
   }
@@ -234,19 +233,21 @@ export class AppService {
   }
 
   getVelogMainContent(bodyElement) {
+    const VELOG_TITLE_CLASS_NAME = "tbwpx";
+    const VELOG_MAIN_CLASS_NAME = "dftzxp";
     const allElements = Array.from(bodyElement.querySelectorAll("*"));
 
     const titleElement = allElements.find((element) => {
       return (
         typeof element.className === "string" &&
-        element.className.toLowerCase().includes("tbwpx")
+        element.className.toLowerCase().includes(VELOG_TITLE_CLASS_NAME)
       );
     });
 
     const mainElements = allElements.filter((element) => {
       return (
         typeof element.className === "string" &&
-        element.className.toLowerCase().includes("dftzxp")
+        element.className.toLowerCase().includes(VELOG_MAIN_CLASS_NAME)
       );
     });
 


### PR DESCRIPTION
## 개요
### Resolves: #11
1. 비 시맨틱 태그 사이트인 'Velog' 본문 판별 로직을 추가하였습니다.
2. 해당 로직의 테스트 코드를 추가하였습니다.

## 코드 변경 사항
### 1. Velog 본문 판별 함수 추가(`getVelogMainContent()`)
- 함수 추가 (app.service.js)
  - Class명에 "TBWPX"를 포함하는 가장 첫번째 요소가 title 내용을 담고 있으므로, `find`로 추출합니다.
  https://github.com/team-sticky-252/readim-server/blob/359f36bca67f618db9808316aa9881df996303a1/src/app.service.js#L239-L244

  - Class명에 "dFtzxp"을 포함하는 요소의 모든 자식요소가 Main content 내용을 담고 있으므로, `filter`로 추출합니다.
 https://github.com/team-sticky-252/readim-server/blob/359f36bca67f618db9808316aa9881df996303a1/src/app.service.js#L246-L251
 
     이후, title과 main content를 결합합니다.

### 2. 리딩 타임 계산 함수에 url 판별 로직 추가.
- 시맨틱 본문 판별 로직이 velog에 대응하지 않아, url에 "velog" 포함시 별도의 함수로 판별합니다.
(`getReadingTime()`)
- url 판별을 위해 url인자가 추가되었습니다(formettedURL 값 입력)
https://github.com/team-sticky-252/readim-server/blob/359f36bca67f618db9808316aa9881df996303a1/src/app.service.js#L35-L46

## 기타 전달 사항
- X

## PR Checklist

<!---- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
