### PR TITLE
Refactor: /articleSummary response body  id 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "globals": "^15.6.0",
         "jsdom": "^24.1.0",
         "reflect-metadata": "^0.1.13",
-        "rxjs": "^7.5.5"
+        "rxjs": "^7.5.5",
+        "uuid": "^10.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.18.6",
@@ -12039,6 +12040,18 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
@@ -21078,6 +21091,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
+    },
+    "uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
     },
     "v8-to-istanbul": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "globals": "^15.6.0",
     "jsdom": "^24.1.0",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.5.5"
+    "rxjs": "^7.5.5",
+    "uuid": "^10.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.18.6",

--- a/src/app.controller.js
+++ b/src/app.controller.js
@@ -1,4 +1,5 @@
 import { Controller, Dependencies, Get, Bind, Req, Res } from "@nestjs/common";
+import { v4 as uuid } from "uuid";
 
 import { AppService } from "./app.service";
 import { HttpError, HttpStatus } from "./utils/http";
@@ -33,6 +34,7 @@ export class AppController {
       return response.status(HttpStatus.OK.statusCode).send({
         statusCode: HttpStatus.OK.statusCode,
         data: {
+          id: uuid(),
           readingTime,
           ...siteOpenGraph,
           createDate: new Date().toISOString(),

--- a/src/app.service.js
+++ b/src/app.service.js
@@ -208,8 +208,7 @@ export class AppService {
     const title =
       this.getOpenGraph("title", headElement) ||
       headElement.querySelector("title")?.textContent;
-    const faviconUrl =
-      headElement.querySelector("link[rel*='icon']")?.href || null;
+    const faviconUrl = headElement.querySelector("link[rel*='icon']")?.href;
     const siteMatchName = url.match(SITE_NAME_REGEX);
     const siteName =
       this.getOpenGraph("site_name", headElement) ||


### PR DESCRIPTION
## 개요

Resolves: #17

## 코드 변경 사항

- Card 컴포넌트의 key로 사용할 값을 위해 기존의 GET /articleSummary 의 응답의 body에 id 값을 추가했습니다.

[수정 전]

```js
{
  readingTime: 870000,
  title: "site title",
  siteName: "site name",
  url: "https://www.example.com",
  faviconUrl: "faviconUrl",
  createDate: "2024-06-24T10:55:57.019Z",
}
```


[수정 후]

```js
{
  id: "0274bdb8-70de-4576-87b4-2af8ca39d13c",
  readingTime: 870000,
  title: "site title",
  siteName: "site name",
  url: "https://www.example.com",
  faviconUrl: "faviconUrl",
  createDate: "2024-06-24T10:55:57.019Z",
}
```

## 기타 전달 사항



## PR Checklist
- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
