### PR TITLE
Feat: 본문 판별 알고리즘 개선(tistory)

### DIFF
--- a/src/app.controller.js
+++ b/src/app.controller.js
@@ -101,4 +101,50 @@ export class AppController {
       },
     });
   }
+
+  @Get("/tistory")
+  @Bind(Req(), Res())
+  async getTistoryArticle(request, response) {
+    const { url } = request.query;
+
+    try {
+      const formattedURL = this.appService.formatHttpURL(url);
+
+      const { bodyElement } =
+        await this.appService.getHtmlElement(formattedURL);
+      const article = this.appService.getMainContent(bodyElement);
+
+      return response.status(HttpStatus.OK.statusCode).send({
+        statusCode: HttpStatus.OK.statusCode,
+        data: {
+          article,
+        },
+      });
+    } catch (e) {
+      try {
+        const formattedURL = this.appService.formatHttpURL(url);
+
+        const { bodyElement } =
+          await this.appService.getHtmlElement(formattedURL);
+        const article = this.appService.getTistoryMainContent(bodyElement);
+
+        return response.status(HttpStatus.OK.statusCode).send({
+          statusCode: HttpStatus.OK.statusCode,
+          data: {
+            article,
+          },
+        });
+      } catch (error) {
+        if (error instanceof HttpError) {
+          const { statusCode, message } = error.getError();
+
+          return response.status(statusCode).send({ statusCode, message });
+        }
+
+        const { statusCode, message } = HttpStatus.INTERNAR_SERVER_ERROR;
+
+        return response.status(statusCode).send({ statusCode, message });
+      }
+    }
+  }
 }

--- a/src/app.controller.js
+++ b/src/app.controller.js
@@ -21,11 +21,7 @@ export class AppController {
 
       const { headElement, bodyElement } =
         await this.appService.getHtmlElement(formattedURL);
-      const readingTime = this.appService.getReadingTime(
-        formattedURL,
-        bodyElement,
-        wpm,
-      );
+      const readingTime = this.appService.getReadingTime(bodyElement, wpm);
       const siteOpenGraph = this.appService.getSiteOpenGraph(
         headElement,
         formattedURL,
@@ -61,9 +57,7 @@ export class AppController {
     try {
       const formattedURL = this.appService.formatHttpURL(url);
 
-      const { bodyElement } =
-        await this.appService.getHtmlElement(formattedURL);
-      const article = this.appService.getMainContent(bodyElement);
+      const article = await this.appService.getMainContent(formattedURL);
 
       return response.status(HttpStatus.OK.statusCode).send({
         statusCode: HttpStatus.OK.statusCode,
@@ -81,70 +75,6 @@ export class AppController {
       const { statusCode, message } = HttpStatus.INTERNAR_SERVER_ERROR;
 
       return response.status(statusCode).send({ statusCode, message });
-    }
-  }
-
-  @Get("/velog")
-  @Bind(Req(), Res())
-  async getArticlebody(request, response) {
-    const { url } = request.query;
-
-    const formattedURL = this.appService.formatHttpURL(url);
-
-    const { bodyElement } = await this.appService.getHtmlElement(formattedURL);
-    const article = this.appService.getVelogMainContent(bodyElement);
-
-    return response.status(HttpStatus.OK.statusCode).send({
-      statusCode: HttpStatus.OK.statusCode,
-      data: {
-        article,
-      },
-    });
-  }
-
-  @Get("/tistory")
-  @Bind(Req(), Res())
-  async getTistoryArticle(request, response) {
-    const { url } = request.query;
-
-    try {
-      const formattedURL = this.appService.formatHttpURL(url);
-
-      const { bodyElement } =
-        await this.appService.getHtmlElement(formattedURL);
-      const article = this.appService.getMainContent(bodyElement);
-
-      return response.status(HttpStatus.OK.statusCode).send({
-        statusCode: HttpStatus.OK.statusCode,
-        data: {
-          article,
-        },
-      });
-    } catch (e) {
-      try {
-        const formattedURL = this.appService.formatHttpURL(url);
-
-        const { bodyElement } =
-          await this.appService.getHtmlElement(formattedURL);
-        const article = this.appService.getTistoryMainContent(bodyElement);
-
-        return response.status(HttpStatus.OK.statusCode).send({
-          statusCode: HttpStatus.OK.statusCode,
-          data: {
-            article,
-          },
-        });
-      } catch (error) {
-        if (error instanceof HttpError) {
-          const { statusCode, message } = error.getError();
-
-          return response.status(statusCode).send({ statusCode, message });
-        }
-
-        const { statusCode, message } = HttpStatus.INTERNAR_SERVER_ERROR;
-
-        return response.status(statusCode).send({ statusCode, message });
-      }
     }
   }
 }

--- a/src/app.controller.js
+++ b/src/app.controller.js
@@ -21,7 +21,11 @@ export class AppController {
 
       const { headElement, bodyElement } =
         await this.appService.getHtmlElement(formattedURL);
-      const readingTime = this.appService.getReadingTime(bodyElement, wpm);
+      const readingTime = this.appService.getReadingTime(
+        bodyElement,
+        wpm,
+        formattedURL,
+      );
       const siteOpenGraph = this.appService.getSiteOpenGraph(
         headElement,
         formattedURL,
@@ -57,7 +61,10 @@ export class AppController {
     try {
       const formattedURL = this.appService.formatHttpURL(url);
 
-      const article = await this.appService.getMainContent(formattedURL);
+      const { bodyElement } =
+        await this.appService.getHtmlElement(formattedURL);
+
+      const article = this.appService.getMainContent(bodyElement, formattedURL);
 
       return response.status(HttpStatus.OK.statusCode).send({
         statusCode: HttpStatus.OK.statusCode,

--- a/src/app.controller.spec.js
+++ b/src/app.controller.spec.js
@@ -148,7 +148,7 @@ describe("AppController", () => {
 
       const mainContentElements =
         appService.reduceSemanticMainContent(bodyElement);
-      const content = appService.getMainContent(bodyElement);
+      const content = appService.getSemanticMainContent(bodyElement);
 
       expect(mainContentElements.length).toBe(2);
       expect(content).toBe("title section1 section2 div1 div2 div3 div4");

--- a/src/app.controller.spec.js
+++ b/src/app.controller.spec.js
@@ -147,7 +147,7 @@ describe("AppController", () => {
       const bodyElement = dom.window.document.querySelector("body");
 
       const mainContentElements =
-        appService.reduceMainContentElements(bodyElement);
+        appService.reduceSemanticMainContent(bodyElement);
       const content = appService.getMainContent(bodyElement);
 
       expect(mainContentElements.length).toBe(2);
@@ -214,13 +214,95 @@ describe("AppController", () => {
       const { JSDOM } = jsdom;
       const dom = new JSDOM(html);
       const bodyElement = dom.window.document.querySelector("body");
-      console.log(bodyElement.innerHTML);
+
       const velogMaincontent = appService
         .getVelogMainContent(bodyElement)
         .replace(/\s+/g, " ");
 
       expect(velogMaincontent).toBe(
         ` Velog(벨로그) 본문 추출법 2024년 6월 24일 난수로 보이지만 규칙이 있습니다 클래스 명에 "TBWPX"를 포함하는 첫번째 div와 그 자식들만 title 정보를 담고 있습니다 그리고, 클래스명에 "dFtzxp"를 포함하는 div와 그 자식요소들이 본문 요소들을 담고 있습니다 `,
+      );
+    });
+  });
+
+  describe("getTistoryMainContents", () => {
+    it("should remove excluded elements on semantic page", () => {
+      const appService = app.get(AppService);
+
+      const html = `<!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta charset="UTF-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <title>Document</title>
+        </head>
+        <body>
+          <article>
+            <p>article 태그의 하위 텍스트 노드를 가져옵니다.</p>
+            <div>
+              <p>특정 요소를 제외한 나머지 텍스트 노드를 가져옵니다.</p>
+            </div>
+            <div class="summary">
+              <div>클래스명에 제외해야 할 단어가 포함된 경우 해당 요소와 그 하위 요소는 출력되지 않습니다.</div>
+            </div>
+            <div id="paging">
+              <p>id명에 제외해야 할 단어가 포함된 경우 해당 요소와 하위 요소는 출력되지 않습니다.</p>
+              <div>
+                <p>하위요소는 출력되지 않습니다.</p>
+              </div>
+            </div>
+          </article>
+        </body>
+      </html>`;
+
+      const { JSDOM } = jsdom;
+      const dom = new JSDOM(html);
+      const bodyElement = dom.window.document.querySelector("body");
+
+      const tistoryMaincontent = appService.getTistoryMainContent(bodyElement);
+
+      expect(tistoryMaincontent).toBe(
+        "article 태그의 하위 텍스트 노드를 가져옵니다. 특정 요소를 제외한 나머지 텍스트 노드를 가져옵니다.",
+      );
+    });
+
+    it("should remove excluded elements on non-semantic page", () => {
+      const appService = app.get(AppService);
+
+      const html = `<!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta charset="UTF-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <title>Document</title>
+        </head>
+        <body>
+          <div class="tt_article_useless_p_margin">
+            <p>클래스명 tt_article_useless_p_margin을 본문(main)으로 판별하고 하위 텍스트 노드를 가져옵니다.</p>
+            <div>
+              <p>특정 요소를 제외한 나머지 텍스트 노드를 가져옵니다.</p>
+            </div>
+            <div class="footer">
+              <div>클래스명에 제외해야 할 단어가 포함된 경우 해당 요소와 그 하위 요소는 출력되지 않습니다.</div>
+            </div>
+            <div id="player">
+              <p>id명에 제외해야 할 단어가 포함된 경우 해당 요소와 하위 요소는 출력되지 않습니다.</p>
+              <div class="article">
+                <p>하위요소는 출력되지 않습니다.</p>
+              </div>
+            </div>
+          </div>
+        </body>
+      </html>`;
+
+      const { JSDOM } = jsdom;
+      const dom = new JSDOM(html);
+      const bodyElement = dom.window.document.querySelector("body");
+
+      const tistoryMaincontent = appService.getTistoryMainContent(bodyElement);
+
+      expect(tistoryMaincontent).toBe(
+        "클래스명 tt_article_useless_p_margin을 본문(main)으로 판별하고 하위 텍스트 노드를 가져옵니다. 특정 요소를 제외한 나머지 텍스트 노드를 가져옵니다.",
       );
     });
   });

--- a/src/app.service.js
+++ b/src/app.service.js
@@ -10,7 +10,7 @@ const EXCLUDED_CLASS_NAMES_REGEX =
 const EXCLUDED_ID_REGEX = /(paging|player|sidebar)/i;
 const MAIN_CONTENT_TAGS_REGEX = /^(main|article|section)$/i;
 const MAIN_CONTENT_CSS_REGEX =
-  /^(tt_article_useless_p_margin|area_view|contents_style|contents_style|article_skin)$/i;
+  /(tt_article_useless_p_margin|area_view|contents_style|contents_style|article_skin)/i;
 const MAIN_CONTENT_SELECTOR_NAME = [
   "#article-view",
   "#mArticle",

--- a/src/app.service.js
+++ b/src/app.service.js
@@ -141,7 +141,7 @@ export class AppService {
   convertCodeTagToText(element) {
     const tagName = element.tagName.toLowerCase();
 
-    if (tagName === "pre") {
+    if (tagName === "code") {
       const text = this.convertCodeToText(element.textContent);
 
       element.innerHTML = text;

--- a/src/app.service.js
+++ b/src/app.service.js
@@ -6,8 +6,8 @@ import { HttpError, HttpStatus } from "./utils/http";
 const EXCLUDED_TAGS_REGEX =
   /^(button|img|nav|aside|footer|audio|canvas|embed|iframe|map|area|noscript|object|option|optgroup|picture|progress|script|select|source|style|svg|meta)$/i;
 const EXCLUDED_CLASS_NAMES_REGEX =
-  /(button|btn|nav|footer|summary|author|comment|sns|share|card|activity|relate|another|reply|sr-only|post-switch|loof|revenue|act|tag|direction|og|notice)/i;
-const EXCLUDED_ID_REGEX = /(paging|player)/i;
+  /(button|btn|nav|footer|summary|author|comment|sns|share|card|activity|relate|another|reply|sr-only|post-switch|loof|revenue|act|tag|direction|og|notice|tag|rpost|list-unstyled)/i;
+const EXCLUDED_ID_REGEX = /(paging|player|sidebar)/i;
 const MAIN_CONTENT_TAGS_REGEX = /^(main|article|section)$/i;
 const MAIN_CONTENT_CSS_REGEX =
   /^(tt_article_useless_p_margin|area_view|contents_style|contents_style|article_skin)$/i;

--- a/src/app.service.js
+++ b/src/app.service.js
@@ -80,8 +80,7 @@ export class AppService {
     while (stack.length > 0) {
       const currentElement = stack.pop();
       const tagName = currentElement.tagName.toLowerCase();
-      const { className } = currentElement;
-      const { id } = currentElement;
+      const { className, id } = currentElement;
 
       if (EXCLUDED_TAGS_REGEX.test(tagName)) {
         const { parentElement } = currentElement;

--- a/src/app.service.js
+++ b/src/app.service.js
@@ -45,17 +45,15 @@ export class AppService {
     }
   }
 
-  getReadingTime(bodyElement, wpm) {
-    const mainContent = this.getMainContent(bodyElement);
+  getReadingTime(bodyElement, wpm, url) {
+    const mainContent = this.getMainContent(bodyElement, url);
 
     return this.calculateReadingTime(mainContent, wpm);
   }
 
-  async getMainContent(url) {
-    const { bodyElement } = await this.getHtmlElement(url);
-
+  getMainContent(bodyElement, url) {
     try {
-      return await this.getSemanticMainContent(bodyElement);
+      return this.getSemanticMainContent(bodyElement);
     } catch (error) {
       if (url.includes("velog.io")) {
         return this.getVelogMainContent(bodyElement);

--- a/src/app.service.js
+++ b/src/app.service.js
@@ -45,19 +45,13 @@ export class AppService {
     }
   }
 
-  getReadingTime(url, bodyElement, wpm) {
-    if (url.includes("velog.io")) {
-      const velogMainContent = this.getVelogMainContent(bodyElement);
-
-      return this.calculateReadingTime(velogMainContent, wpm);
-    }
-
+  getReadingTime(bodyElement, wpm) {
     const mainContent = this.getMainContent(bodyElement);
 
     return this.calculateReadingTime(mainContent, wpm);
   }
 
-  getMainContent(bodyElement) {
+  getSemanticMainContent(bodyElement) {
     const mainContentElements = this.reduceSemanticMainContent(bodyElement);
 
     const contents = mainContentElements.reduce((acc, element) => {
@@ -337,5 +331,23 @@ export class AppService {
     }, []);
 
     return mainArticle.join(" ").trim().replace(/\\/g, "");
+  }
+
+  async getMainContent(url) {
+    const { bodyElement } = await this.getHtmlElement(url);
+
+    try {
+      return await this.getSemanticMainContent(bodyElement);
+    } catch (error) {
+      if (url.includes("velog.io")) {
+        return this.getVelogMainContent(bodyElement);
+      }
+
+      if (url.includes("tistory.com")) {
+        return this.getTistoryMainContent(bodyElement);
+      }
+    }
+
+    return null;
   }
 }


### PR DESCRIPTION
## 개요
### Resolves: #12
<!---- 변경 사항 및 관련 이슈가 있다면 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
`tistory`는 유저의 커스텀 스킨으로 인해 시멘틱 태그를 통한 구분이 불가능한 경우가 있어 별도의 판별 알고리즘을 작성하였습니다.
`tistory`는 조사해본 결과 크게 두가지 구조로 구분할 수 있었습니다.
1. 시멘틱을 지키고 있는 구조
`main`, `article`, `section` 등

2. 시멘틱을 지키지 않고 특정 단어를 사용해 클래스명으로 식별하는 구조
`class="article-xxx"`, `class="content_xxx"`, `class="area_xxx"` 등

최대한 많은 커스텀 스킨을 판별할 수 있도록 확장 가능성을 염두하여 작성하였습니다.

## 코드 변경 사항
- 중첩 `try..catch`문을 통해 기존에 작성된 시맨틱 아티클 판별 알고리즘을 통해 먼저 판별가능한지 확인하고 유효하지 않아 `error`를 던지는 경우 `tistory` 판별 알고리즘으로 판별할 수 있도록 하였습니다.
https://github.com/team-sticky-252/readim-server/blob/35d2b7adcfac409b26878cda1fdc8e7171535e77/src/app.controller.js#L123-L129
- 시멘틱하지 않은 경우를 판별할 수 있는 `className`의 공통된 단어를 상수화하여 확장 가능하도록 작성하였습니다.
https://github.com/team-sticky-252/readim-server/blob/35d2b7adcfac409b26878cda1fdc8e7171535e77/src/app.service.js#L12-L21
- 본문 내에서 사용자가 읽는 범위로 판단되지 않는 `className`의 공통된 단어를 상수화하여 확장 가능하도록 작성하였습니다.
https://github.com/team-sticky-252/readim-server/blob/35d2b7adcfac409b26878cda1fdc8e7171535e77/src/app.service.js#L8-L9
- 시멘틱한 스킨과 시멘틱을 준수하지 않은 스킨에 대한 경우에 대해 테스트 코드를 작성하였습니다.
- 기존 `convertCodeTagToText()` 함수는 본문의 태그를 순회하며 `pre` 태그내에 `code` 블럭의 단어를 구분하여 문자열로 반환하도록 작성되어 있었습니다. 이를 통해 카멜케이스로 작성된 `className`을 단어별로 구분하여 총 단어수를 집계하였는데 인라인 코드는 카멜케이스에 대응하고 있지 않아 일관성 있는 단어수 집계를 위해 대상 범위를 `pre` 태그에서 `code`로 변경하였습니다.


## 기타 전달 사항
조사한 범위내에서 본문으로 판별할 수 있는 `css selector`는 다음과 같습니다.
- `id` : `article-view`
- `className` : `tt_article_useless_p_margin`, `contents_style`, `area_view`, `contents_style`

본문 내에서 판별대상으로 제외되어야 하는 `css selector`는 다음과 같습니다.
- `className`: `container_postbtn`, `#post_button_group`


## PR Checklist
- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
