### PR TITLE
Refactor: 가져올 OpenGraph 정보의 타겟을 복수로 설정 가능하도록 수정

### DIFF
--- a/src/app.service.js
+++ b/src/app.service.js
@@ -274,12 +274,12 @@ export class AppService {
 
   getSiteOpenGraph(headElement, url) {
     const title =
-      this.getOpenGraph("title", headElement) ||
+      this.getOpenGraph(headElement, "title") ||
       headElement.querySelector("title")?.textContent;
     const faviconUrl = headElement.querySelector("link[rel*='icon']")?.href;
     const siteMatchName = url.match(SITE_NAME_REGEX);
     const siteName =
-      this.getOpenGraph(["site_name", "article:author"], headElement) ||
+      this.getOpenGraph(headElement, ["site_name", "article:author"]) ||
       (siteMatchName && siteMatchName[1]);
 
     return {
@@ -290,11 +290,7 @@ export class AppService {
     };
   }
 
-  getOpenGraph(properties, headElement) {
-    if (!Array.isArray(properties)) {
-      properties = [properties];
-    }
-
+  getOpenGraph(headElement, ...properties) {
     return properties
       .map(
         (property) =>

--- a/src/app.service.js
+++ b/src/app.service.js
@@ -279,7 +279,7 @@ export class AppService {
     const faviconUrl = headElement.querySelector("link[rel*='icon']")?.href;
     const siteMatchName = url.match(SITE_NAME_REGEX);
     const siteName =
-      this.getOpenGraph("site_name", headElement) ||
+      this.getOpenGraph(["site_name", "article:author"], headElement) ||
       (siteMatchName && siteMatchName[1]);
 
     return {
@@ -290,10 +290,19 @@ export class AppService {
     };
   }
 
-  getOpenGraph(property, headElement) {
-    return headElement.querySelector(
-      `meta[property='og:${property}'], meta[name='${property}']`,
-    )?.content;
+  getOpenGraph(properties, headElement) {
+    if (!Array.isArray(properties)) {
+      properties = [properties];
+    }
+
+    return properties
+      .map(
+        (property) =>
+          headElement.querySelector(
+            `meta[property='og:${property}'], meta[name='${property}']`,
+          )?.content,
+      )
+      .find((content) => content !== undefined);
   }
 
   formatHttpURL(url) {


### PR DESCRIPTION
## 개요
### Resolves: #23
1. getOpenGraph() 함수에서 가져올 타겟을 복수로 설정할 수 있습니다.

## 코드 변경 사항

1. getOpenGraph() 함수에서 가져올 타겟을 복수로 설정할 수 있습니다.
https://github.com/team-sticky-252/readim-server/blob/390272767079cf0b975901d68fd16f41fd6e4774/src/app.service.js#L281-L306

## 기타 전달 사항

- X

## PR Checklist

<!---- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
