### PR TITLE
Feat: Server 배포용 port 대응

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "readim",
   "version": "0.0.0",
+  "engines": {
+    "node": "18.16.0"
+  },
   "scripts": {
     "format": "prettier --write \"**/*.js\"",
     "start": "babel-node index.js",
@@ -21,7 +24,8 @@
     "jsdom": "^24.1.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.5.5",
-    "uuid": "^10.0.0"
+    "uuid": "^10.0.0",
+    "husky": "^8.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.18.6",
@@ -39,7 +43,6 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
-    "husky": "^8.0.0",
     "jest": "^28.1.2",
     "lint-staged": "^15.2.0",
     "nodemon": "^3.1.3",

--- a/src/main.js
+++ b/src/main.js
@@ -3,12 +3,13 @@ import { AppModule } from "./app.module";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-
+  const port = process.env.SERVER_PORT || 3000;
   app.enableCors({
-    origin: "http://localhost:5173",
+    origin: ["http://localhost:5173", "https://testreadim.netlify.app/"],
     methods: "GET",
   });
 
-  await app.listen(3000);
+  await app.listen(port);
 }
+
 bootstrap();


### PR DESCRIPTION
## 개요
#31
1. AWS Elastic BeansTalk Port(8080)에 대응하였습니다.
2. Package.json 파일에 node.js 버전 등을 표시하였습니다.

## 코드 변경 사항
1. AWS 환경 변수 대응
https://github.com/team-sticky-252/readim-server/blob/a1aa46ca1cffd3c8a6a7933bcc868a14e019b565/src/main.js#L4-L13

## 기타 전달 사항

<!---- 리뷰어들에게 기능관련 외에 전달하고 싶은 사항을 작성해주세요. -->

## PR Checklist

<!---- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
