### PR TITLE
Refactor: API 요청시 리딩 타임 반환 로직에서 본문 데이터 추가해 반환하는 로직으로 변경

### DIFF
--- a/src/app.controller.js
+++ b/src/app.controller.js
@@ -21,11 +21,17 @@ export class AppController {
 
       const { headElement, bodyElement } =
         await this.appService.getHtmlElement(formattedURL);
-      const readingTime = this.appService.getReadingTime(
+
+      const mainContent = this.appService.getMainContent(
         bodyElement,
-        wpm,
         formattedURL,
       );
+
+      const readingTime = this.appService.calculateReadingTime(
+        mainContent,
+        wpm,
+      );
+
       const siteOpenGraph = this.appService.getSiteOpenGraph(
         headElement,
         formattedURL,
@@ -36,6 +42,7 @@ export class AppController {
         data: {
           id: uuid(),
           readingTime,
+          mainContent,
           ...siteOpenGraph,
           createDate: new Date().toISOString(),
         },

--- a/src/app.service.js
+++ b/src/app.service.js
@@ -45,12 +45,6 @@ export class AppService {
     }
   }
 
-  getReadingTime(bodyElement, wpm, url) {
-    const mainContent = this.getMainContent(bodyElement, url);
-
-    return this.calculateReadingTime(mainContent, wpm);
-  }
-
   getMainContent(bodyElement, url) {
     try {
       return this.getSemanticMainContent(bodyElement);


### PR DESCRIPTION
## 개요
client 에서 OpenAI API 를 통한 본문 내용 요약에 본문 데이터가 필요하여 반환 데이터에 본문 데이터를 추가하였습니다.

## 코드 변경 사항
- 기존 getReadingTime() 을 통해 반환되었던 reading time을 두개의 함수로 분리하여 reading time과 main content를 반환받도록 했습니다.
https://github.com/team-sticky-252/readim-server/blob/4b438e0eaff66cf8a55def2fa3da295f6d93e7a2/src/app.controller.js#L25-L33

## 기타 전달 사항

<!---- 리뷰어들에게 기능관련 외에 전달하고 싶은 사항을 작성해주세요. -->

## PR Checklist

<!---- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
