### PR TITLE
Fix: getSiteOpenGraph 함수 수정

### DIFF
--- a/src/app.service.js
+++ b/src/app.service.js
@@ -273,7 +273,7 @@ export class AppService {
     const faviconUrl = headElement.querySelector("link[rel*='icon']")?.href;
     const siteMatchName = url.match(SITE_NAME_REGEX);
     const siteName =
-      this.getOpenGraph(headElement, ["site_name", "article:author"]) ||
+      this.getOpenGraph(headElement, "site_name", "article:author") ||
       (siteMatchName && siteMatchName[1]);
 
     return {

--- a/src/app.service.js
+++ b/src/app.service.js
@@ -274,6 +274,7 @@ export class AppService {
     const siteMatchName = url.match(SITE_NAME_REGEX);
     const siteName =
       this.getOpenGraph(headElement, "site_name", "article:author") ||
+      this.getOpenGraph(headElement, "twitter:site")?.split("@")[1] ||
       (siteMatchName && siteMatchName[1]);
 
     return {


### PR DESCRIPTION
## 개요

```js
getOpenGraph(headElement, ...properties) {
   ...
}
```
Rest parameter를 사용하는 함수를 호출할 때 전달하는 인수를 변경했습니다.

## 코드 변경 사항
[변경 전]
`this.getOpenGraph(headElement, ["site_name", "article:author"])`

[변경 후]
`this.getOpenGraph(headElement, "site_name", "article:author")` 




## 기타 전달 사항
- X

## PR Checklist
- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
