### PR TITLE
Refactor: reading time 초 단위 반올림 로직 변경

### DIFF
--- a/src/app.service.js
+++ b/src/app.service.js
@@ -63,23 +63,9 @@ export class AppService {
 
   calculateReadingTime(articleBody, wpm) {
     const numOfWords = articleBody.split(" ").length;
-    const rawReadingTime = (numOfWords / wpm) * 60 * 1000;
-    let readingMinutes = Math.floor(rawReadingTime / 1000 / 60);
-    let readingSeconds =
-      Math.round((rawReadingTime / 1000 - readingMinutes * 60) * 0.1) * 10;
+    const readingTimeMs = (numOfWords / wpm) * 60 * 1000;
 
-    if (readingSeconds >= 45) {
-      readingMinutes += 1;
-      readingSeconds = 0;
-    } else if (readingSeconds >= 15) {
-      readingSeconds = 30;
-    } else {
-      readingSeconds = 0;
-    }
-
-    const readingTimePerMs = readingMinutes * 60 * 1000 + readingSeconds * 1000;
-
-    return readingTimePerMs;
+    return readingTimeMs;
   }
 
   getSemanticMainContent(bodyElement) {

--- a/src/app.service.js
+++ b/src/app.service.js
@@ -63,7 +63,7 @@ export class AppService {
 
   calculateReadingTime(articleBody, wpm) {
     const numOfWords = articleBody.split(" ").length;
-    const readingTimeMs = (numOfWords / wpm) * 60 * 1000;
+    const readingTimeMs = Math.floor((numOfWords / wpm) * 60 * 1000);
 
     return readingTimeMs;
   }


### PR DESCRIPTION
## 개요
- 현재 0초, 30초 단위로 변환하여 화면에 보여주는 것을 초 단위 그대로 화면에 나타내기 위해 예상 읽기 시간(millisecond)을 그대로 응답 값으로 넘겨주는 것으로 수정했습니다.

## 코드 변경 사항
<!---- 어떻게 코드를 작성 및 수정했는지 설명해주세요. 필요한 경우 코드 라인 링크를 활용해주세요. -->
- 소수점 이하는 제외한 reading time(millisecond) 정수값을 그대로 반환합니다.
https://github.com/team-sticky-252/readim-server/blob/faeb2755d63a7ddc93959d7d2cc8164a359343cb/src/app.service.js#L64-L69

## 기타 전달 사항
- X

## PR Checklist
- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
