### PR TITLE
Fix: convertCodeToText() 내 조건문 수정

### DIFF
--- a/src/app.service.js
+++ b/src/app.service.js
@@ -243,13 +243,13 @@ export class AppService {
   }
 
   convertCodeToText(code) {
-    const CodeText = code
+    const codeText = code
       .replace(/([a-z])([A-Z])/g, "$1 $2")
       .replace(/[{}\[\]\(\)<>\/;┤├┌─┐└┘┬┴┼│\./"/'/`@,:=\-_!|+?$*\\]/g, " ")
       .replace(/\s+/g, " ")
       .trim();
 
-    return CodeText;
+    return codeText;
   }
 
   getSiteOpenGraph(headElement, url) {

--- a/src/app.service.js
+++ b/src/app.service.js
@@ -151,7 +151,7 @@ export class AppService {
   convertCodeTagToText(element) {
     const tagName = element.tagName.toLowerCase();
 
-    if (tagName === "code") {
+    if (tagName === "pre" || tagName === "code") {
       const text = this.convertCodeToText(element.textContent);
 
       element.innerHTML = text;


### PR DESCRIPTION
<!---- <타입>: <일감 명> 의 형식으로 제목 작성 -->

## 개요
GET /articleSummary 호출 시 `<code>`  태그의 텍스트를 가져와 요소 내의 텍스트를 추출하는 부분이 제대로 동작하지 않아 수정이 필요했습니다.

아래와 같은 코드 블럭이 아티클에 있을 경우
```js
import { useState } from 'react';
```

기대한 값
```
import useState from react
```

실제 값
```
import { useState } from 'react' ;
```

## 코드 변경 사항
- convertCodeToText() 내 조건문을 추가했습니다.
https://github.com/team-sticky-252/readim-server/blob/616d9676054dadc8ba0ca1f86b129bfa7cc66b99/src/app.service.js#L154

## 기타 전달 사항
- X

## PR Checklist
- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
