### PR TITLE
Refactor: Headless Browser 실행 및 종료 로직 리팩터링

### DIFF
--- a/src/app.service.js
+++ b/src/app.service.js
@@ -442,8 +442,6 @@ export class AppService {
   }
 
   async extractMainContent(url) {
-    console.time();
-    console.log("Start Puppeteer");
     function browserCloseTimer() {
       if (browserCloseTimeout) {
         clearTimeout(browserCloseTimeout);
@@ -529,8 +527,6 @@ export class AppService {
 
       const mainText = this.parseElementIntoTextContent(bestElement);
 
-      console.log("End Puppeteer");
-      console.timeEnd();
       return mainText;
     }
 

--- a/src/classes/BrowserService.js
+++ b/src/classes/BrowserService.js
@@ -1,0 +1,70 @@
+import puppeteer from "puppeteer";
+
+export default class BrowserService {
+  constructor() {
+    if (!BrowserService.instance) {
+      this.headlessBrowser = null;
+      this.browserCloseTimeout = null;
+    }
+  }
+
+  static getInstance() {
+    if (!BrowserService.instance) {
+      BrowserService.instance = new BrowserService();
+    }
+
+    return BrowserService.instance;
+  }
+
+  async startBrowser() {
+    if (!this.headlessBrowser || !this.headlessBrowser.isConnected()) {
+      this.headlessBrowser = await puppeteer.launch();
+    }
+  }
+
+  async visitPage(url) {
+    await this.startBrowser();
+
+    const page = await this.headlessBrowser.newPage();
+
+    await page.setRequestInterception(true);
+    page.on("request", (request) => {
+      if (
+        ["image", "stylesheet", "font", "media"].includes(
+          request.resourceType(),
+        )
+      ) {
+        request.abort();
+      } else {
+        request.continue();
+      }
+    });
+
+    await page.goto(url, { waitUntil: "networkidle0" });
+
+    const iframeElement = await page.$("iframe#mainFrame");
+
+    let content;
+
+    if (iframeElement) {
+      const frame = await iframeElement.contentFrame();
+      content = await frame.content();
+    } else {
+      content = await page.content();
+    }
+
+    return content;
+  }
+
+  startBrowserCloseTimer() {
+    if (this.browserCloseTimeout) {
+      clearTimeout(this.browserCloseTimeout);
+    }
+
+    this.browserCloseTimeout = setTimeout(async () => {
+      if (this.headlessBrowser && this.headlessBrowser.isConnected()) {
+        await this.headlessBrowser.close();
+      }
+    }, 300000);
+  }
+}


### PR DESCRIPTION
## 개요
### 사유:
Headless browser 실행에 막대한 리소스가 소요됨으로 인해 서버에 큰 부담이 부과되지만, browser를 URL별로 독립적으로 실행시키고 있습니다.

### 변경사항:
각각의 요청에 독립적으로 Puppeteer의 Headless Browser를 실행 및 종료하던 로직을 다음과 같이 수정했습니다.
(이하 browser)

- 첫번째 요청에 browser를 실행하고, browser 종료 명령을 5분뒤에 실행시키는 `setTimeout` 타이머를 등록합니다.
- 이후, 5분 이내에 새로운 요청이 도달할 경우, 해당 타이머를 삭제하고 재등록(갱신)합니다.
- 5분 동안 새로운 요청이 없는 경우 타이머가 실행되어 browser가 종료됩니다.

## 코드 변경 사항

### 기존 코드
https://github.com/team-sticky-252/readim-server/blob/b570646fa2f4aead1d56b15f39a52f6c088f2e86/src/app.service.js#L442-L471

### 변경 코드
BrowserService 클래스
https://github.com/team-sticky-252/readim-server/blob/2b31892d515231190f54013d48df0a2b82851270/src/classes/BrowserService.js#L3-L70

기존 로직 대채
https://github.com/team-sticky-252/readim-server/blob/2b31892d515231190f54013d48df0a2b82851270/src/app.service.js#L442-L447

## 기타 전달 사항

### 서버 수정 사항 안내:
- 서버 인스턴스 사양(1코어[가상], 1GB RAM)으로 인해, Puppeteer요청이 과도할 경우, 메모리 부족으로 인해 서버가 다운되는 현상이 있었습니다.
- 현재는 인스턴스 Swap memory 설정으로 RAM 용량을 2GB 추가하여 해당 현상은 예방하였습니다.
  하지만, 그럼에도 100%에 근접한 CPU 사용 및 3GB의 RAM도 90% 이상 사용되는 것을 볼 수 있습니다.
  따라서, 사용자가 한번에 요청할 수 있는 URL의 개수의 하향 조정이 필요해보입니다.

*) Swap Memory: 서버의 디스크 용량의 일부를 RAM으로 치환하여 메모리를 보충하는 기술.
 
![image](https://github.com/user-attachments/assets/82bc2b52-d94f-4485-aa7e-dbf2a94fcc79)


## PR Checklist

<!---- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 주어진 Task의 요구사항을 모두 작성했습니다.
- [x] 작성한 PR을 다시 한번 더 검토하였습니다.
- [x] merge 할 브랜치의 위치를 확인하였습니다.
